### PR TITLE
Add debug output for HPC context in ink.sh

### DIFF
--- a/ink.sh
+++ b/ink.sh
@@ -97,5 +97,10 @@ fi
 # --- Compose final prompt with real newlines ---
 prompt=$'Using the following HPC environment context:\n'"${ctx}"$'\n\nNow: '"${prompt_input}"
 
+echo "===DEBUG CONTEXT START==="
+printf '%s\n' "$ctx"
+echo "===DEBUG CONTEXT END==="
+
+
 # --- Call Inkly ---
 exec "$INKLY_BIN" -p "$prompt"


### PR DESCRIPTION
Prints the HPC environment context to the console for debugging purposes before executing Inkly. This helps verify the context being passed to the prompt.