### PR TITLE
Update Node.js setup to use version 20 with nvm

### DIFF
--- a/Container/inkly1.def
+++ b/Container/inkly1.def
@@ -97,8 +97,9 @@ if ! command -v node >/dev/null 2>&1; then
   export NVM_DIR="$HOME/.nvm"
   set +u
   . "$NVM_DIR/nvm.sh"
-  nvm install --lts
-  nvm use --lts
+  nvm install 20
+  nvm alias default 20
+  nvm use 20
 
   # Capture Node binary path for runtime use
   NODE_BIN_DIR="$(dirname "$(command -v node)")"


### PR DESCRIPTION
Changed nvm installation commands to explicitly install and use Node.js version 20, and set it as the default version. This ensures consistent Node.js environment across builds.