### PR TITLE
Add run script for Inkly build and install

### DIFF
--- a/Container/run .sh
+++ b/Container/run .sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Running Inkly build and install scripts"
+bash ./build.sh 
+bash ./install.sh
+echo "Inkly build and install complete"
+
+ink "Hello"
+


### PR DESCRIPTION
Introduces run.sh to automate the build and installation process for Inkly, including execution of build.sh and install.sh scripts, and a test invocation of the 'ink' command.