### PR TITLE
#29 Replace symlink with copy for ink installation

### DIFF
--- a/Container/install.sh
+++ b/Container/install.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-set -euo pipefail
+set -e
 
-echo "Installing ink launcher"
+echo "==> Installing ink launcher"
 
 mkdir -p "$HOME/.local/bin"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-cp "$SCRIPT_DIR/ink" "$HOME/.local/bin/ink"
+cp -f "$SCRIPT_DIR/ink" "$HOME/.local/bin/ink"
 chmod +x "$HOME/.local/bin/ink"
 
-echo "ink installed to $HOME/.local/bin/ink"
-echo "Ensure ~/.local/bin is in your PATH"
+echo "==> ink installed to ~/.local/bin/ink"
+
+echo ""
+echo "Make sure ~/.local/bin is in your PATH:"
+echo "export PATH=\"\$HOME/.local/bin:\$PATH\""


### PR DESCRIPTION
Changed the install script to copy the ink executable to ~/.local/bin instead of creating a symlink. This ensures the binary is present even if the source directory is moved or deleted.